### PR TITLE
fix: Remove unused anyhow dependency from Cargo.toml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,12 +53,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.100"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
-
-[[package]]
 name = "clap"
 version = "4.5.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,7 +102,6 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 name = "drift"
 version = "20260201.0.0"
 dependencies = [
- "anyhow",
  "clap",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,5 @@ description = "Repo drift auditor - checks for stale configs, version mismatches
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
-anyhow = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,9 +140,10 @@ fn check_dead_code_markers() -> Vec<Issue> {
             for entry in entries.filter_map(|e| e.ok()) {
                 let path = entry.path();
                 if path.is_dir() {
-                    if path.file_name().is_some_and(|n| {
-                        n != "target" && n != ".git" && n != "node_modules"
-                    }) {
+                    if path
+                        .file_name()
+                        .is_some_and(|n| n != "target" && n != ".git" && n != "node_modules")
+                    {
                         walk_source(&path, markers, issues);
                     }
                 } else if path.is_file() {


### PR DESCRIPTION
## Issue
Closes #20: `Cargo.toml:9` - Unused dependency `anyhow` declared but never imported or used anywhere in the codebase

## Why this issue?
Simplest possible fix - just remove one line from Cargo.toml. Zero risk, zero code changes needed, immediately verifiable with cargo build. High impact-to-effort ratio as it cleans up the dependency tree.

## Fix
Remove unused anyhow dependency from Cargo.toml

This fix was developed through Claude + Codex + Gemini consensus.

---
Automated fix by lok pick-and-fix workflow.