### PR TITLE
fix: Replace no-op test with assertions that validate Issue struct fields are non-empty

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,21 @@ mod tests {
 
     #[test]
     fn test_run_audit_returns_vec() {
-        // Should return a vec without panicking (may be empty in a clean repo)
-        let _issues = run_audit();
+        let issues = run_audit();
+        // Verify that any issues found are well-formed
+        for issue in &issues {
+            assert!(
+                !issue.category.is_empty(),
+                "Issue category should not be empty"
+            );
+            assert!(
+                !issue.severity.is_empty(),
+                "Issue severity should not be empty"
+            );
+            assert!(
+                !issue.message.is_empty(),
+                "Issue message should not be empty"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Issue
Closes #22: `src/lib.rs:257` - Unused test variable `_issues` - the test calls `run_audit()` but doesn't assert anything on the result, making it a no-op test

## Why this issue?
This is a clearly defined, minimal fix - just add assertions to an existing test. It's the highest impact-to-effort ratio because it improves test coverage with a one-line change, and doesn't require any refactoring or architectural decisions.

## Fix
Replace no-op test with assertions that validate Issue struct fields are non-empty

This fix was developed through Claude + Codex + Gemini consensus.

---
Automated fix by lok pick-and-fix workflow.